### PR TITLE
Report HTTP errors when no parser for content type

### DIFF
--- a/lib/attachQuadStream.js
+++ b/lib/attachQuadStream.js
@@ -15,7 +15,10 @@ function attachQuadStream (res, fetch, parsers) {
 
     // is there a parser for the content?
     if (!parsers.has(contentType)) {
-      return Promise.reject(new Error(`unknown content type: ${contentType}`))
+      if (!res.ok) {
+        return Promise.reject(new Error(`Fetching failed with HTTP${res.status}`))
+      }
+      return Promise.reject(new Error(`No parser for content type: ${contentType}`))
     }
 
     let jsonldContext

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@rdfjs/formats-common": "^2.0.0",
     "mocha": "^5.2.0",
     "nock": "^10.0.0",
+    "rdf-ext": "^1.3.0",
     "standard": "^12.0.1"
   },
   "engines": {


### PR DESCRIPTION
I often get this unhelpful error message:

```
Error: unknown content type: text/html
    at Response.res.quadStream (/node_modules/@rdfjs/fetch-lite/lib/attachQuadStream.js:18:29)
    at Response.res.dataset (/node_modules/@rdfjs/fetch-lite/lib/attachDataset.js:5:30)
    at fetch (/fetch.js:45:31)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

The cause usually being the `fetch`ed request responding with an HTTP error. The above error is misleading: I'm asking for `application/n-triples` from an endpoint that returns `application/n-triples` when all is well. When the server has issues it returns 500 or 404 or any other HTTP error and this goes unnoticed, the only clue being that the error page is `text/html`.

(This morning for instance <http://rdfs.org/sioc/ns#> returns 404 instead of the ontology usually available over there.)